### PR TITLE
chapter-list: refactored and added new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,26 +61,32 @@ These methods must all be run using `object:function()` syntax so that they act 
 
 #### Methods meant to control the list overlay:
 
-| Method        | Description                                 |
-|---------------|---------------------------------------------|
-| open()        | opens the list                              |
-| close()       | closes the list                             |
-| toggle()      | toggles the list                            |
-| update()      | re-scan the list and update the osd overlay |
-| scroll_down() | move cursor down                            |
-| scroll_up()   | move cursor up                              |
+| Method          | Description                                 |
+|---------------  |---------------------------------------------|
+| open()          | opens the list                              |
+| close()         | closes the list                             |
+| toggle()        | toggles the list                            |
+| update()        | re-scan the list and update the osd overlay |
+| scroll_down()   | move cursor down                            |
+| scroll_up()     | move cursor up                              |
+| move_pagedown() | move cursor to next page                    |
+| move_pagedup()  | move cursor to previous page                |
+| move_begin()    | move cursor to begin                        |
+| move_end()      | move cursor to end                          |
 
 #### Methods designed to be replaceable for custom behaviour:
 Changing these can break the script if certain function calls are missing. Make sure to check the defaults.
 
-| Method                   | Description                                                                                                                    |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| format_header()          | formats and prints the header to the overlay                                                                                   |
-| format_line(index, item) | formats the ass string for the given `item` at list position `index` - this handles the cursor, indents, styles and newlines.  |
-| open()                   | is called by `toggle` - runs the functions required when opening the list                                                      |
-| close()                  | is called by `toggle` - runs the functions required when closing the list                                                      |
+| Method                   | Description                                                  |
+| ------------------------ | ------------------------------------------------------------ |
+| format_header_string()   | format and return the header string - allows one to modify or substitute the header string on each redraw |
+| format_header()          | formats and prints the header to the overlay                 |
+| format_line(index, item) | formats the ass string for the given `item` at list position `index` - this handles the cursor, indents, styles and newlines. |
+| open()                   | is called by `toggle` - runs the functions required when opening the list |
+| close()                  | is called by `toggle` - runs the functions required when closing the list |
 
 #### Methods to support custom functions:
+
 Generally these shouldn't be changed.
 
 | Method            | Description                                                                        |

--- a/examples/chapter-list.lua
+++ b/examples/chapter-list.lua
@@ -1,17 +1,75 @@
 --[[
     This script implements an interractive chapter list
+    Usage: add bindings to input.conf
+    -- key script-message-to chapter_list toggle-chapter-browser
 
     This script was written as an example for the mpv-scroll-list api
     https://github.com/CogentRedTester/mpv-scroll-list
 ]]
 
 local mp = require 'mp'
+local opts = require("mp.options")
+
+local o = {
+    -- header of the list
+    -- %cursor% and %total% to be used to display the cursor position and the total number of lists
+    header = "Chapter List [%cursor%/%total%]\\N ------------------------------------",
+    -- wrap the cursor around the top and bottom of the list
+    wrap = true,
+    -- reset cursor navigation when open the list
+    reset_cursor_on_close = true,
+    -- set dynamic keybinds to bind when the list is open
+    key_move_begin = "HOME",
+    key_move_end = "END",
+    key_move_pageup = "PGUP",
+    key_move_pagedown = "PGDWN",
+    key_scroll_down = "DOWN WHEEL_DOWN",
+    key_scroll_up = "UP WHEEL_UP",
+    key_open_chapter = "ENTER MBTN_LEFT",
+    key_close_browser = "ESC MBTN_RIGHT",
+}
+
+opts.read_options(o)
 
 --adding the source directory to the package path and loading the module
 local list = dofile(mp.command_native({"expand-path", "~~/script-modules/scroll-list.lua"}))
 
 --modifying the list settings
-list.header = "Chapter List \\N ------------------------------------"
+local original_open = list.open
+list.header = o.header
+list.wrap = o.wrap
+
+--escape header specifies the format
+--display the cursor position and the total number of lists in the header
+function list:format_header_string(str)
+    if #list.list > 0 then
+        str = str:gsub("%%(%a+)%%", { cursor = list.selected, total = #list.list })
+    else str = str:gsub("%[.*%]", "") end
+    return str
+end
+
+--update the list when the current chapter changes
+mp.observe_property('chapter', 'number', function(_, curr_chapter)
+    list.list = {}
+    local chapter_list = mp.get_property_native('chapter-list', {})
+    for i = 1, #chapter_list do
+        local item = {}
+        if (i - 1 == curr_chapter) then
+            list.selected = curr_chapter + 1
+            item.style = [[{\c&H33ff66&}]]
+        end
+
+        local time = chapter_list[i].time
+        local title = chapter_list[i].title
+        if title == "" then title = "Chapter " .. string.format("%02.f", i) end
+        if time < 0 then time = 0
+        else time = math.floor(time) end
+        item.ass = string.format("[%02d:%02d:%02d]", math.floor(time/60/60), math.floor(time/60)%60, time%60)
+        item.ass = item.ass..'\\h\\h\\h'..list.ass_escape(title)
+        list.list[i] = item
+    end
+    list:update()
+end)
 
 --jump to the selected chapter
 local function open_chapter()
@@ -20,32 +78,39 @@ local function open_chapter()
     end
 end
 
---dynamic keybinds to bind when the list is open
-list.keybinds = {
-    {'DOWN', 'scroll_down', function() list:scroll_down() end, {repeatable = true}},
-    {'UP', 'scroll_up', function() list:scroll_up() end, {repeatable = true}},
-    {'ENTER', 'open_chapter', open_chapter, {} },
-    {'ESC', 'close_browser', function() list:close() end, {}}
-}
-
---update the list when the current chapter changes
-mp.observe_property('chapter', 'number', function(_, curr_chapter)
-    list.list = {}
-    local chapter_list = mp.get_property_native('chapter-list', {})
-    for i = 1, #chapter_list do
-        local item = {}
-        if (i-1 == curr_chapter) then
-            item.style = [[{\c&H33ff66&}]]
+--reset cursor navigation when open the list
+local function reset_cursor()
+    if o.reset_cursor_on_close then
+        if mp.get_property('chapter') then
+            list.selected = mp.get_property_number('chapter') + 1
+            list:update()
         end
-
-        local time = chapter_list[i].time
-        if time < 0 then time = 0
-        else time = math.floor(time) end
-        item.ass = string.format("[%02d:%02d:%02d]", math.floor(time/60/60), math.floor(time/60)%60, time%60)
-        item.ass = item.ass..'\\h\\h\\h'..list.ass_escape(chapter_list[i].title)
-        list.list[i] = item
     end
-    list:update()
-end)
+end
 
-mp.add_key_binding("Shift+F8", "toggle-chapter-browser", function() list:toggle() end)
+function list:open()
+    reset_cursor()
+    original_open(self)
+end
+
+--dynamic keybinds to bind when the list is open
+list.keybinds = {}
+
+local function add_keys(keys, name, fn, flags)
+    local i = 1
+    for key in keys:gmatch("%S+") do
+      table.insert(list.keybinds, {key, name..i, fn, flags})
+      i = i + 1
+    end
+end
+
+add_keys(o.key_scroll_down, 'scroll_down', function() list:scroll_down() end, {repeatable = true})
+add_keys(o.key_scroll_up, 'scroll_up', function() list:scroll_up() end, {repeatable = true})
+add_keys(o.key_move_pageup, 'move_pageup', function() list:move_pageup() end, {})
+add_keys(o.key_move_pagedown, 'move_pagedown', function() list:move_pagedown() end, {})
+add_keys(o.key_move_begin, 'move_begin', function() list:move_begin() end, {})
+add_keys(o.key_move_end, 'move_end', function() list:move_end() end, {})
+add_keys(o.key_open_chapter, 'open_chapter', open_chapter, {})
+add_keys(o.key_close_browser, 'close_browser', function() list:close() end, {})
+
+mp.register_script_message("toggle-chapter-browser", function() list:toggle() end)

--- a/scroll-list.lua
+++ b/scroll-list.lua
@@ -43,6 +43,11 @@ function scroll_list.ass_escape(str, replace_newline)
     return str
 end
 
+--format and return the header string
+function scroll_list:format_header_string(str)
+    return str
+end
+
 --appends the entered text to the overlay
 function scroll_list:append(text)
         if text == nil then return end
@@ -64,7 +69,7 @@ end
 --prints the header to the overlay
 function scroll_list:format_header()
     self:append(self.header_style)
-    self:append(self.header)
+    self:append(self:format_header_string(self.header))
     self:newline()
 end
 
@@ -147,6 +152,40 @@ function scroll_list:scroll_up()
     end
 end
 
+--moves the selector to the list next page
+function scroll_list:move_pagedown()
+    if #self.list > self.num_entries then
+        self.selected = self.selected + self.num_entries
+        if self.selected > #self.list then self.selected = #self.list end
+        self:update_ass()
+    end
+end
+
+--moves the selector to the list previous page
+function scroll_list:move_pageup()
+    if #self.list > self.num_entries then
+        self.selected = self.selected - self.num_entries
+        if self.selected < 1 then self.selected = 1 end
+        self:update_ass()
+    end
+end
+
+--moves the selector to the list begin
+function scroll_list:move_begin()
+    if #self.list > 1 then
+        self.selected = 1
+        self:update_ass()
+    end
+end
+
+--moves the selector to the list end
+function scroll_list:move_end()
+    if #self.list > 1 then
+        self.selected = #self.list
+        self:update_ass()
+    end
+end
+
 --adds the forced keybinds
 function scroll_list:add_keybinds()
     for _,v in ipairs(self.keybinds) do
@@ -181,7 +220,7 @@ function scroll_list:open()
 end
 
 --modifiable function that closes the list
-function scroll_list:close ()
+function scroll_list:close()
     self:remove_keybinds()
     self:close_list()
 end
@@ -241,6 +280,10 @@ function scroll_list:new()
         keybinds = {
             {'DOWN', 'scroll_down', function() vars:scroll_down() end, {repeatable = true}},
             {'UP', 'scroll_up', function() vars:scroll_up() end, {repeatable = true}},
+            {'PGDWN', 'move_pagedown', function() vars:move_pagedown() end, {}},
+            {'PGUP', 'move_pageup', function() vars:move_pageup() end, {}},
+            {'HOME', 'move_begin', function() vars:move_begin() end, {}},
+            {'END', 'move_end', function() vars:move_end() end, {}},
             {'ESC', 'close_browser', function() vars:close() end, {}}
         }
     }


### PR DESCRIPTION
optimize scroll-list.lua:
- add format_header_string function for custom behaviour.
- add more methods and keybinds meant to control the list overlay.

refactor chapter-list.lua:
- add mouse control and options
- display the cursor position and the total number of lists in the header
- when the menu is first opened now the new behavior of list.selected is to select the current chapter
- reset cursor navigation when open the list, also add option to control whether this behavior is enabled(default)